### PR TITLE
support multiple jiras

### DIFF
--- a/lib/tickets.js
+++ b/lib/tickets.js
@@ -42,132 +42,141 @@ module.exports = function tickets(opts, callback) {
     return U.die('No files found', callback);
   }
 
-  var re = new RegExp('[^a-zA-Z0-9](' + ((cfg.keys === '+') ? '[A-Z][_A-Z0-9]*' : '(?:' + cfg.keys.join('|') + ')') + '-[1-9][0-9]*)[^a-zA-Z0-9]', 'gm');
-  var issues = {};
-
-  files.forEach(function forEach(file) {
-    var path = file.substr(dirLn);
-
-    var contents = fs.readFileSync(file, {
-      encoding: 'UTF-8'
+  if (typeof cfg.jira === 'string') {
+    jira(cfg);
+  }else if (Object.prototype.toString.call( cfg.jira ) === '[object Array]') {
+    _.forEach(cfg.jira, function(jiraCfg){
+      jira(_.merge(cfg, jiraCfg, { jira: jiraCfg.url }));
     });
-
-    var matches;
-
-    while ((matches = re.exec(contents)) !== null) {
-
-      if (!issues[matches[1]]) {
-        issues[matches[1]] = {
-          key: matches[1],
-          files: {}
-        };
-      }
-
-      if (!issues[matches[1]].files[path]) {
-        issues[matches[1]].files[path] = [];
-      }
-
-      var line = (contents.substr(0, matches.index).match(/\n/g) || []).length + 1;
-
-      if (issues[matches[1]].files[path].indexOf(line) === -1) {
-        issues[matches[1]].files[path].push(line);
-      }
-    }
-
-  });
-
-  issues = _.values(issues);
-
-  var ln = issues.length;
-
-  if (ln === 0) {
-    return U.die('No issues found', callback);
   }
 
-  callback || console.info('Looking up ' + ln + ' issues..');
+  function jira(cfg){
+    var re = new RegExp('[^a-zA-Z0-9](' + ((cfg.keys === '+') ? '[A-Z][_A-Z0-9]*' : '(?:' + cfg.keys.join('|') + ')') + '-[1-9][0-9]*)[^a-zA-Z0-9]', 'gm');
+    var issues = {};
 
-  async.eachLimit(issues, 3, function(issue, cb) {
+    files.forEach(function forEach(file) {
+      var path = file.substr(dirLn);
 
-    request({
-      url: cfg.jira + '/rest/api/2/issue/' + issue.key,
-      method: 'GET',
-      auth: cfg.username ? {
-        username: cfg.username,
-        password: cfg.password
-      } : null
-    }, function(err, response, body) {
-      var data;
+      var contents = fs.readFileSync(file, {
+        encoding: 'UTF-8'
+      });
 
-      if (!err) {
+      var matches;
 
-        if (response.statusCode >= 400) {
-          err = response.statusCode;
+      while ((matches = re.exec(contents)) !== null) {
 
-        } else {
-
-          try {
-            data = JSON.parse(body);
-            if (data.errorMessages) {
-              err = data.errorMessages.join(', ');
-            }
-
-          } catch (e) {
-            err = e.message;
-          }
-        }
-      }
-
-      if (err) {
-        issue.error = util.format(
-          'Request to Jira for issue "%s" failed with: %d.',
-          issue.key, err
-        );
-
-      } else {
-        issue.fields = data.fields;
-      }
-
-      if (!callback) {
-        console.log();
-
-        if (issue.error) {
-          console.log(chalk.cyan(U.strPadRight(issue.key, 15)) + chalk.red(issue.error));
-
-        } else {
-          console.log(chalk.cyan(U.strPadRight(issue.key, 15)) + issue.fields.summary);
-          console.log(chalk.cyan(U.strPadRight('Updated', 15)) + issue.fields.updated);
-          console.log(chalk.cyan(U.strPadRight('Status', 15)) + chalk[chalk[issue.fields.status.statusCategory.colorName] ? issue.fields.status.statusCategory.colorName : 'white'](issue.fields.status.name));
-          issue.fields.resolution && console.log(chalk.cyan(U.strPadRight('Resolution', 15)) + issue.fields.resolution.name);
-          issue.fields.priority && console.log(chalk.cyan(U.strPadRight('Priority', 15)) + issue.fields.priority.name);
+        if (!issues[matches[1]]) {
+          issues[matches[1]] = {
+            key: matches[1],
+            files: {}
+          };
         }
 
-        var firstFile = _.keys(issue.files)[0];
+        if (!issues[matches[1]].files[path]) {
+          issues[matches[1]].files[path] = [];
+        }
 
-        console.log(chalk.cyan(U.strPadRight('Files', 15)) + firstFile + ' #' + issue.files[firstFile].join(', #'));
+        var line = (contents.substr(0, matches.index).match(/\n/g) || []).length + 1;
 
-        _.each(_.omit(issue.files, firstFile), function forEachFile(lines, file) {
-          console.log(U.repeat(' ', 15) + file + ' #' + lines.join(', #'));
-        });
+        if (issues[matches[1]].files[path].indexOf(line) === -1) {
+          issues[matches[1]].files[path].push(line);
+        }
       }
-
-      cb();
 
     });
 
-  }, function(err) {
+    issues = _.values(issues);
 
-    if (err) {
-      return U.die(err);
+    var ln = issues.length;
+
+    if (ln === 0) {
+      return U.die('No issues found', callback);
     }
 
-    if (callback) {
-      callback(null, issues);
+    callback || console.info('Looking up ' + ln + ' issues..');
 
-    } else {
-      console.log();
-      console.log(chalk.green('Found ' + ln + ' issues'));
-    }
+    async.eachLimit(issues, 3, function(issue, cb) {
 
-  });
+      request({
+        url: cfg.jira + '/rest/api/2/issue/' + issue.key,
+        method: 'GET',
+        auth: cfg.username ? {
+          username: cfg.username,
+          password: cfg.password
+        } : null
+      }, function(err, response, body) {
+        var data;
 
+        if (!err) {
+
+          if (response.statusCode >= 400) {
+            err = response.statusCode;
+
+          } else {
+
+            try {
+              data = JSON.parse(body);
+              if (data.errorMessages) {
+                err = data.errorMessages.join(', ');
+              }
+
+            } catch (e) {
+              err = e.message;
+            }
+          }
+        }
+
+        if (err) {
+          issue.error = util.format(
+            'Request to Jira for issue "%s" failed with: %d.',
+            issue.key, err
+          );
+
+        } else {
+          issue.fields = data.fields;
+        }
+
+        if (!callback) {
+          console.log();
+
+          if (issue.error) {
+            console.log(chalk.cyan(U.strPadRight(issue.key, 15)) + chalk.red(issue.error));
+
+          } else {
+            console.log(chalk.cyan(U.strPadRight(issue.key, 15)) + issue.fields.summary);
+            console.log(chalk.cyan(U.strPadRight('Updated', 15)) + issue.fields.updated);
+            console.log(chalk.cyan(U.strPadRight('Status', 15)) + chalk[chalk[issue.fields.status.statusCategory.colorName] ? issue.fields.status.statusCategory.colorName : 'white'](issue.fields.status.name));
+            issue.fields.resolution && console.log(chalk.cyan(U.strPadRight('Resolution', 15)) + issue.fields.resolution.name);
+            issue.fields.priority && console.log(chalk.cyan(U.strPadRight('Priority', 15)) + issue.fields.priority.name);
+          }
+
+          var firstFile = _.keys(issue.files)[0];
+
+          console.log(chalk.cyan(U.strPadRight('Files', 15)) + firstFile + ' #' + issue.files[firstFile].join(', #'));
+
+          _.each(_.omit(issue.files, firstFile), function forEachFile(lines, file) {
+            console.log(U.repeat(' ', 15) + file + ' #' + lines.join(', #'));
+          });
+        }
+
+        cb();
+
+      });
+
+    }, function(err) {
+
+      if (err) {
+        return U.die(err);
+      }
+
+      if (callback) {
+        callback(null, issues);
+
+      } else {
+        console.log();
+        console.log(chalk.green('Found ' + ln + ' issues'));
+      }
+
+    });
+  }
 };

--- a/test/simple_test.js
+++ b/test/simple_test.js
@@ -67,6 +67,31 @@ describe('Tickets', function() {
 
 		});
 
+		it('should find tickets of two JIRAs', function(done){
+
+			tickets({
+				dir: path.resolve('test', 'fixtures', 'all'),
+		    jira: [
+	        {
+	          url: 'https://jira.appcelerator.org/',
+	          keys: ['TIMOB', 'ALOY']
+	        },{
+	          url: 'https://jira.appcelerator.org/',
+	          keys: ['TC']
+	        }
+		    ]
+			}, function(err, issues){
+				if (err) {
+					throw err;
+				}
+
+				issues.should.be.an.Array;
+
+				done();
+			});
+
+		});
+
 	});
 
 });


### PR DESCRIPTION
I added the functionality that I've requested in #2 

It's actually a minor modification but let me explain why it's such a big diff:

I extracted the whole ticket-searching-process into a separate `jira`-method. If there's only one jira, this method gets called and does exactly the same thing as it did before. But if it's setup for multiple JIRAs it is able to repeat it for every jira configuration.

**Example:**

Your code has references to JIRA tickets in the appcelerator JIRA (_TIMOB-72554, ALOY-1151, etc._) **and** tickets of your own / your companies JIRA (let's call it _https://my-company.atlassian.net/_) with project related tickets (e.g. _MYAPP-123, MYAPP-999, etc._). Then you can set it up like this:

``` javascript
tickets({
  dir: 'app',
  jira: [
    {
      url: 'https://jira.appcelerator.org/',
      keys: ['TIMOB', 'ALOY']
    },{
      url: 'https://my-company.atlassian.net/',
      keys: ['MYAPP'],
      username: 'myname',
      password: 'mypassword'
    }
  ]
}, function(err, issues){
  // ..
});
```

What do you think?
