### PR TITLE
skip undefined fixVersions

### DIFF
--- a/lib/tickets.js
+++ b/lib/tickets.js
@@ -191,7 +191,7 @@ module.exports = function tickets(opts, callback) {
             issue.fields.resolution && console.log(chalk.cyan(U.strPadRight('Resolution', 15)) + issue.fields.resolution.name);
             issue.fields.priority && console.log(chalk.cyan(U.strPadRight('Priority', 15)) + issue.fields.priority.name);
 
-            if (issue.fields.fixVersions.length > 0) {
+            if (issue.fields.fixVersions && issue.fields.fixVersions.length > 0) {
 
               label = 'Fix Version(s)';
               _.each(issue.fields.fixVersions, function forEachVersion(version) {


### PR DESCRIPTION
fixVersions may be not set (undefined), e.g. on TC tickets

```
Looking up 5 issues..

TC-4613        Support Widgets and Require in ListItem Templates
Updated        2014-09-06T06:44:35.000+0000
Status         Open

TypeError: Cannot read property 'length' of undefined
    at Request._callback (/usr/local/lib/node_modules/tickets/lib/tickets.js:194:41)
    at Request.self.callback (/usr/local/lib/node_modules/tickets/node_modules/request/request.js:199:22)
    at Request.EventEmitter.emit (events.js:98:17)
    at Request.<anonymous> (/usr/local/lib/node_modules/tickets/node_modules/request/request.js:1160:14)
    at Request.EventEmitter.emit (events.js:117:20)
    at IncomingMessage.<anonymous> (/usr/local/lib/node_modules/tickets/node_modules/request/request.js:1111:12)
    at IncomingMessage.EventEmitter.emit (events.js:117:20)
    at _stream_readable.js:920:16
    at process._tickCallback (node.js:415:13)
```
