### PR TITLE
increase mocha timeout

### DIFF
--- a/test/simple_test.js
+++ b/test/simple_test.js
@@ -5,6 +5,8 @@ var should = require('should');
 var tickets = require('../lib/tickets');
 
 describe('Tickets', function() {
+	
+	this.timeout(20000);
 
 	describe('#simple', function() {
 


### PR DESCRIPTION
Sometimes Jira needs more than 3000ms to respond. That's why #8 failed.
